### PR TITLE
Bug: not passing an otherButtonTitle in the UIAlertView init method mean...

### DIFF
--- a/UIAlertView+Blocks.m
+++ b/UIAlertView+Blocks.m
@@ -33,12 +33,14 @@ static const void *UIAlertViewShouldEnableFirstOtherButtonBlockKey  = &UIAlertVi
                                                  message:message
                                                 delegate:nil
                                        cancelButtonTitle:cancelButtonTitle
-                                       otherButtonTitles:nil];
+                                       otherButtonTitles:[otherButtonTitles firstObject], nil];
     
     alertView.alertViewStyle = style;
     
-    for (NSString *buttonTitle in otherButtonTitles) {
-        [alertView addButtonWithTitle:buttonTitle];
+    if (otherButtonTitles.count > 1) {
+        for (NSString *buttonTitle in [otherButtonTitles subarrayWithRange:NSMakeRange(1, otherButtonTitles.count - 1)]) {
+            [alertView addButtonWithTitle:buttonTitle];
+        }
     }
     
     if (tapBlock) {


### PR DESCRIPTION
...s firstOtherButtonIndex isn't set correctly!

So I've modified the creation of the UIAlertView so it passes the first other button title and then adds any additional ones separately.
