### PR TITLE
NSArray firstObject is available only since iOS7.

### DIFF
--- a/UIAlertView+Blocks.m
+++ b/UIAlertView+Blocks.m
@@ -49,11 +49,13 @@ static const void *UIAlertViewShouldEnableFirstOtherButtonBlockKey  = &UIAlertVi
             otherButtonTitles:(NSArray *)otherButtonTitles
                      tapBlock:(UIAlertViewCompletionBlock)tapBlock {
     
+    NSString *firstObject = [otherButtonTitles count] ? [otherButtonTitles objectAtIndex:0] : nil;
+    
     UIAlertView *alertView = [[self alloc] initWithTitle:title
                                                  message:message
                                                 delegate:nil
                                        cancelButtonTitle:cancelButtonTitle
-                                       otherButtonTitles:[otherButtonTitles firstObject], nil];
+                                       otherButtonTitles:firstObject, nil];
     
     alertView.alertViewStyle = style;
     


### PR DESCRIPTION
NSArray firstObject was used and is only available since iOS7. The change I propose doesn't use it and keeps compatibility with older SDKs (which according to the readme and the podspec are still supported).

Hope it helps.
