### PR TITLE
Add factory methods to return UIAlertView without showing it

### DIFF
--- a/UIAlertView+Blocks.h
+++ b/UIAlertView+Blocks.h
@@ -33,6 +33,23 @@ typedef void (^UIAlertViewCompletionBlock) (UIAlertView *alertView, NSInteger bu
 
 @interface UIAlertView (Blocks)
 
+#pragma mark - Build
+
++ (instancetype)alertViewWithTitle:(NSString *)title
+                           message:(NSString *)message
+                             style:(UIAlertViewStyle)style
+                 cancelButtonTitle:(NSString *)cancelButtonTitle
+                 otherButtonTitles:(NSArray *)otherButtonTitles
+                          tapBlock:(UIAlertViewCompletionBlock)tapBlock;
+
++ (instancetype)alertViewWithTitle:(NSString *)title
+                           message:(NSString *)message
+                 cancelButtonTitle:(NSString *)cancelButtonTitle
+                 otherButtonTitles:(NSArray *)otherButtonTitles
+                          tapBlock:(UIAlertViewCompletionBlock)tapBlock;
+
+#pragma mark - Build and show
+
 + (instancetype)showWithTitle:(NSString *)title
                       message:(NSString *)message
                         style:(UIAlertViewStyle)style

--- a/UIAlertView+Blocks.m
+++ b/UIAlertView+Blocks.m
@@ -42,40 +42,75 @@ static const void *UIAlertViewShouldEnableFirstOtherButtonBlockKey  = &UIAlertVi
 
 @implementation UIAlertView (Blocks)
 
+#pragma mark - Build
+
++ (instancetype)alertViewWithTitle:(NSString *)title
+                           message:(NSString *)message
+                             style:(UIAlertViewStyle)style
+                 cancelButtonTitle:(NSString *)cancelButtonTitle
+                 otherButtonTitles:(NSArray *)otherButtonTitles
+                          tapBlock:(UIAlertViewCompletionBlock)tapBlock {
+
+    NSString *firstObject = otherButtonTitles.count ? otherButtonTitles[0] : nil;
+
+    UIAlertView *alertView = [[self alloc] initWithTitle:title
+                                                 message:message
+                                                delegate:nil
+                                       cancelButtonTitle:cancelButtonTitle
+                                       otherButtonTitles:firstObject, nil];
+
+    alertView.alertViewStyle = style;
+
+    if (otherButtonTitles.count > 1) {
+        for (NSString *buttonTitle in [otherButtonTitles subarrayWithRange:NSMakeRange(1, otherButtonTitles.count - 1)]) {
+            [alertView addButtonWithTitle:buttonTitle];
+        }
+    }
+
+    if (tapBlock) {
+        alertView.tapBlock = tapBlock;
+    }
+
+#if !__has_feature(objc_arc)
+    return [alertView autorelease];
+#else
+    return alertView;
+#endif
+}
+
++ (instancetype)alertViewWithTitle:(NSString *)title
+                           message:(NSString *)message
+                 cancelButtonTitle:(NSString *)cancelButtonTitle
+                 otherButtonTitles:(NSArray *)otherButtonTitles
+                          tapBlock:(UIAlertViewCompletionBlock)tapBlock {
+
+    return [self alertViewWithTitle:title
+                            message:message
+                              style:UIAlertViewStyleDefault
+                  cancelButtonTitle:cancelButtonTitle
+                  otherButtonTitles:otherButtonTitles
+                           tapBlock:tapBlock];
+}
+
+#pragma mark - Buil and show
+
 + (instancetype)showWithTitle:(NSString *)title
                       message:(NSString *)message
                         style:(UIAlertViewStyle)style
             cancelButtonTitle:(NSString *)cancelButtonTitle
             otherButtonTitles:(NSArray *)otherButtonTitles
                      tapBlock:(UIAlertViewCompletionBlock)tapBlock {
-    
-    NSString *firstObject = otherButtonTitles.count ? otherButtonTitles[0] : nil;
-    
-    UIAlertView *alertView = [[self alloc] initWithTitle:title
-                                                 message:message
-                                                delegate:nil
-                                       cancelButtonTitle:cancelButtonTitle
-                                       otherButtonTitles:firstObject, nil];
-    
-    alertView.alertViewStyle = style;
-    
-    if (otherButtonTitles.count > 1) {
-        for (NSString *buttonTitle in [otherButtonTitles subarrayWithRange:NSMakeRange(1, otherButtonTitles.count - 1)]) {
-            [alertView addButtonWithTitle:buttonTitle];
-        }
-    }
-    
-    if (tapBlock) {
-        alertView.tapBlock = tapBlock;
-    }
-    
+
+    UIAlertView *alertView = [self alertViewWithTitle:title
+                                              message:message
+                                                style:style
+                                    cancelButtonTitle:cancelButtonTitle
+                                    otherButtonTitles:otherButtonTitles
+                                             tapBlock:tapBlock];
+
     [alertView show];
-    
-#if !__has_feature(objc_arc)
-    return [alertView autorelease];
-#else
+
     return alertView;
-#endif
 }
 
 


### PR DESCRIPTION
The factory methods to build and show the configured `UIAlertView` in one shot are pretty handy. In some cases though I'd like to build the alert view but don't show it straightaway.

I know that this is possible using the `initWithTitle:message:delegate:cancelButtonTitle:otherButtonTitles:` method and setting the `tapBlock` afterwards, but I like the simplicity of the factory method.
